### PR TITLE
Reuse GitLab client, make student setup fully idempotent

### DIFF
--- a/server/infrastructureSetup/gitlab.go
+++ b/server/infrastructureSetup/gitlab.go
@@ -2,6 +2,9 @@ package infrastructureSetup
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/prompt-edu/prompt-intro-course/server/infrastructureSetup/data"
 	log "github.com/sirupsen/logrus"
@@ -12,35 +15,93 @@ const IN_PROGRESS_LABEL_ID int64 = 53319
 const IN_REVIEW_LABEL_ID int64 = 53320
 const ASE_GROUP_ID int64 = 186940
 
-func getClient() (*gitlab.Client, error) {
-	// Create a client
-	git, err := gitlab.NewClient(InfrastructureServiceSingleton.gitlabAccessToken, gitlab.WithBaseURL("https://gitlab.lrz.de/api/v4"))
-	if err != nil {
-		log.Error("Failed to create client: ", err)
-		return nil, err
-	}
-	return git, nil
+var errGitLabClientNotInitialized = errors.New("gitlab client not initialized")
 
+func getClient() (*gitlab.Client, error) {
+	if InfrastructureServiceSingleton.gitlabClient == nil {
+		return nil, errGitLabClientNotInitialized
+	}
+	return InfrastructureServiceSingleton.gitlabClient, nil
 }
 
-func createCourseIterationGroup(courseIteration string, parentID int64) (*gitlab.Group, error) {
-	// Create a top level group
+// isAlreadyExistsError checks whether a GitLab API error indicates the resource
+// already exists. It checks for 409 Conflict by status code, and for APIs that
+// return 400 with "already exists" in the structured response message.
+//
+// String matching is intentionally restricted to the gitlab.ErrorResponse.Message
+// field (not the full wrapped error chain) to avoid false positives from network
+// errors or wrapping context that happens to contain matching substrings.
+func isAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errResp *gitlab.ErrorResponse
+	if errors.As(err, &errResp) && errResp.Response != nil {
+		code := errResp.Response.StatusCode
+		if code == http.StatusConflict {
+			return true
+		}
+		// Only string-match on the structured API response message,
+		// not the full wrapped error chain, to avoid false positives.
+		msg := errResp.Message
+		return strings.Contains(msg, "already exists") ||
+			strings.Contains(msg, "already a member") ||
+			strings.Contains(msg, "already been taken")
+	}
+	return false
+}
+
+// findSubGroup searches for a subgroup by name under the given parent.
+// Returns the group if found, nil if not found, or an error on API failure.
+func findSubGroup(groupName string, parentGroupID int64) (*gitlab.Group, error) {
 	git, err := getClient()
 	if err != nil {
 		return nil, err
 	}
 
-	exists, group, err := checkIfSubGroupExists(courseIteration, parentID)
+	groups, _, err := git.Groups.ListSubGroups(parentGroupID, &gitlab.ListSubGroupsOptions{
+		Search:       gitlab.Ptr(groupName),
+		AllAvailable: gitlab.Ptr(true),
+		ListOptions:  gitlab.ListOptions{PerPage: 100},
+	})
 	if err != nil {
-		log.Error("failed to create course iteration group: ", err)
+		return nil, fmt.Errorf("list subgroups of %d: %w", parentGroupID, err)
+	}
+
+	for _, group := range groups {
+		if group.Name == groupName && group.ParentID == parentGroupID {
+			return group, nil
+		}
+	}
+	return nil, nil
+}
+
+func getSubGroup(groupName string, parentGroupID int64) (*gitlab.Group, error) {
+	group, err := findSubGroup(groupName, parentGroupID)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return nil, fmt.Errorf("subgroup %q not found under group %d", groupName, parentGroupID)
+	}
+	return group, nil
+}
+
+func createCourseIterationGroup(courseIteration string, parentID int64) (*gitlab.Group, error) {
+	existing, err := findSubGroup(courseIteration, parentID)
+	if err != nil {
+		return nil, fmt.Errorf("check if course iteration group %q exists: %w", courseIteration, err)
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	git, err := getClient()
+	if err != nil {
 		return nil, err
 	}
 
-	if exists {
-		return group, nil
-	}
-
-	group, _, err = git.Groups.CreateGroup(&gitlab.CreateGroupOptions{
+	group, _, err := git.Groups.CreateGroup(&gitlab.CreateGroupOptions{
 		Name:                  gitlab.Ptr(courseIteration),
 		ParentID:              gitlab.Ptr(parentID),
 		ProjectCreationLevel:  gitlab.Ptr(gitlab.MaintainerProjectCreation),
@@ -49,8 +110,15 @@ func createCourseIterationGroup(courseIteration string, parentID int64) (*gitlab
 		Path:                  gitlab.Ptr(courseIteration),
 	})
 	if err != nil {
-		log.Error("failed to create course iteration group: ", err)
-		return nil, err
+		if !isAlreadyExistsError(err) {
+			return nil, fmt.Errorf("create course iteration group %q: %w", courseIteration, err)
+		}
+		// Race: another request created it between our check and create
+		existing, findErr := findSubGroup(courseIteration, parentID)
+		if findErr != nil || existing == nil {
+			return nil, fmt.Errorf("course iteration group %q conflict but not found: %w", courseIteration, err)
+		}
+		return existing, nil
 	}
 
 	return group, nil
@@ -60,31 +128,26 @@ func createDeveloperTopLevelGroup(parentGroupID int64) (*gitlab.Group, error) {
 	return createGitlabGroup(parentGroupID, "developer", gitlab.NoOneProjectCreation, gitlab.OwnerSubGroupCreationLevelValue)
 }
 
-// create Groups for tutors and coaches
+// createTeachingGroup creates groups for tutors and coaches.
 func createTeachingGroup(parentGroupID int64, groupName string) (*gitlab.Group, error) {
 	return createGitlabGroup(parentGroupID, groupName, gitlab.DeveloperProjectCreation, gitlab.OwnerSubGroupCreationLevelValue)
 }
 
 func createGitlabGroup(parentGroupID int64, groupName string, projectCreationLevel gitlab.ProjectCreationLevelValue, subGroupCreationLevel gitlab.SubGroupCreationLevelValue) (*gitlab.Group, error) {
-	// Create a top level group
+	existing, err := findSubGroup(groupName, parentGroupID)
+	if err != nil {
+		return nil, fmt.Errorf("check if group %q exists: %w", groupName, err)
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
 	git, err := getClient()
 	if err != nil {
-		log.Error("failed to create group: ", groupName, " due to failed client creation")
 		return nil, err
 	}
 
-	exists, group, err := checkIfSubGroupExists(groupName, parentGroupID)
-	if err != nil {
-		log.Error("failed to create course iteration group: ", err)
-		return nil, err
-	}
-
-	if exists {
-		return group, nil
-	}
-
-	// Create a group
-	group, _, err = git.Groups.CreateGroup(&gitlab.CreateGroupOptions{
+	group, _, err := git.Groups.CreateGroup(&gitlab.CreateGroupOptions{
 		Name:                  gitlab.Ptr(groupName),
 		ParentID:              gitlab.Ptr(parentGroupID),
 		ProjectCreationLevel:  gitlab.Ptr(projectCreationLevel),
@@ -92,10 +155,16 @@ func createGitlabGroup(parentGroupID int64, groupName string, projectCreationLev
 		AutoDevopsEnabled:     gitlab.Ptr(false),
 		Path:                  gitlab.Ptr(groupName),
 	})
-
 	if err != nil {
-		log.Error("failed to create developer group: ", err)
-		return nil, err
+		if !isAlreadyExistsError(err) {
+			return nil, fmt.Errorf("create group %q: %w", groupName, err)
+		}
+		// Race: another request created it between our check and create
+		existing, findErr := findSubGroup(groupName, parentGroupID)
+		if findErr != nil || existing == nil {
+			return nil, fmt.Errorf("group %q conflict but not found: %w", groupName, err)
+		}
+		return existing, nil
 	}
 
 	return group, nil
@@ -104,34 +173,29 @@ func createGitlabGroup(parentGroupID int64, groupName string, projectCreationLev
 func getUserID(username string) (*gitlab.User, error) {
 	git, err := getClient()
 	if err != nil {
-		log.Error("failed to get client: ", err)
-		return nil, err
+		return nil, fmt.Errorf("get client for user lookup %q: %w", username, err)
 	}
 
-	userOpts := &gitlab.ListUsersOptions{
+	users, _, err := git.Users.ListUsers(&gitlab.ListUsersOptions{
 		Username: gitlab.Ptr(username),
-	}
-
-	users, _, err := git.Users.ListUsers(userOpts)
+	})
 	if err != nil {
-		log.Error("failed to get user with username : ", username, ", error: ", err)
-		return nil, err
+		return nil, fmt.Errorf("list users for %q: %w", username, err)
 	}
 
 	if len(users) != 1 || users[0] == nil {
-		log.Error("failed to get user id: user not found")
-		return nil, errors.New("user not found")
+		return nil, fmt.Errorf("user %q not found on GitLab", username)
 	}
 	return users[0], nil
 }
 
-func CreateStudentProject(repoName string, devID, tutorID int64, introCourseID, devGroupID int64, studentName, submissionDeadline string) error {
+func CreateStudentProject(repoName string, devID, tutorID, introCourseID int64, introCourseGroupPath string, devGroupID int64, studentName, submissionDeadline string) error {
 	git, err := getClient()
 	if err != nil {
-		log.Error("failed to get client: ", err)
-		return errors.New("failed create student project")
+		return fmt.Errorf("get client for project %q: %w", repoName, err)
 	}
 
+	// 1. Create project (idempotent: handle conflict by fetching existing)
 	p := &gitlab.CreateProjectOptions{
 		Name:                             gitlab.Ptr(repoName),
 		NamespaceID:                      gitlab.Ptr(introCourseID),
@@ -139,78 +203,81 @@ func CreateStudentProject(repoName string, devID, tutorID int64, introCourseID, 
 		OnlyAllowMergeIfPipelineSucceeds: gitlab.Ptr(true),
 		BuildsAccessLevel:                gitlab.Ptr(gitlab.PrivateAccessControl),
 		ContainerRegistryAccessLevel:     gitlab.Ptr(gitlab.DisabledAccessControl),
-		EnvironmentsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl), // disable environments
-		FeatureFlagsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl), // disable feature flags
-		ForkingAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl), // disable forking
-		InfrastructureAccessLevel:        gitlab.Ptr(gitlab.DisabledAccessControl), // disable infrastructure
-		PackagesEnabled:                  gitlab.Ptr(false),                        // disable packages
-		ReleasesAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl), // disable releases
-		SecurityAndComplianceAccessLevel: gitlab.Ptr(gitlab.DisabledAccessControl), // disable security & compliance
-		SnippetsAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl), // disable snippets
-		WikiAccessLevel:                  gitlab.Ptr(gitlab.DisabledAccessControl), // disable wiki
-		RequirementsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl), // disable requirements
-		ModelExperimentsAccessLevel:      gitlab.Ptr(gitlab.DisabledAccessControl), // disable model experiments
-		ModelRegistryAccessLevel:         gitlab.Ptr(gitlab.DisabledAccessControl), // disable model registry
-		PagesAccessLevel:                 gitlab.Ptr(gitlab.DisabledAccessControl), // disable pages
-		MonitorAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl), // disable monitor
+		EnvironmentsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl),
+		FeatureFlagsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl),
+		ForkingAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl),
+		InfrastructureAccessLevel:        gitlab.Ptr(gitlab.DisabledAccessControl),
+		PackagesEnabled:                  gitlab.Ptr(false),
+		ReleasesAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl),
+		SecurityAndComplianceAccessLevel: gitlab.Ptr(gitlab.DisabledAccessControl),
+		SnippetsAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl),
+		WikiAccessLevel:                  gitlab.Ptr(gitlab.DisabledAccessControl),
+		RequirementsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl),
+		ModelExperimentsAccessLevel:      gitlab.Ptr(gitlab.DisabledAccessControl),
+		ModelRegistryAccessLevel:         gitlab.Ptr(gitlab.DisabledAccessControl),
+		PagesAccessLevel:                 gitlab.Ptr(gitlab.DisabledAccessControl),
+		MonitorAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl),
 	}
 
 	project, _, err := git.Projects.CreateProject(p)
 	if err != nil {
-		log.Error("failed to create project: ", err)
-		return errors.New("failed create student project")
+		if !isAlreadyExistsError(err) {
+			return fmt.Errorf("create project %q: %w", repoName, err)
+		}
+		// Project already exists — fetch by deterministic path
+		projectPath := introCourseGroupPath + "/" + repoName
+		project, _, err = git.Projects.GetProject(projectPath, nil)
+		if err != nil {
+			return fmt.Errorf("fetch existing project %q: %w", projectPath, err)
+		}
+		log.WithField("project", repoName).Info("project already exists, continuing with setup")
 	}
 
-	err = createProjectFiles(git, project.ID, studentName, submissionDeadline)
+	// 2. Create project files (idempotent: skip files that already exist)
+	err = createProjectFiles(git, project.ID, repoName, studentName, submissionDeadline)
 	if err != nil {
 		return err
 	}
 
-	// Add branch protection
+	// 3. Branch protection (idempotent: skip if already protected)
 	_, _, err = git.ProtectedBranches.ProtectRepositoryBranches(project.ID, &gitlab.ProtectRepositoryBranchesOptions{
 		Name:             gitlab.Ptr("main"),
 		PushAccessLevel:  gitlab.Ptr(gitlab.MaintainerPermissions),
 		MergeAccessLevel: gitlab.Ptr(gitlab.DeveloperPermissions),
 	})
-	if err != nil {
-		log.Error("failed to add branch protect rules: ", err)
-		return errors.New("failed add branch protect rules")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("protect branch for %q: %w", repoName, err)
 	}
 
-	err = createIssueBoard(git, project.ID)
+	// 4. Issue board (idempotent: reuse existing board, add missing lists)
+	err = ensureIssueBoard(git, project.ID, repoName)
 	if err != nil {
 		return err
 	}
 
-	// Add project members (Last step as this might fail if the tutor is already a member of a "higher" group)
-	err = addProjectMembers(git, project.ID, tutorID, devID, devGroupID)
+	// 5. Members (idempotent: skip if already a member)
+	err = addProjectMembers(git, project.ID, repoName, tutorID, devID, devGroupID)
 	if err != nil {
 		return err
 	}
 
-	// Add MR approval rule
-	_, _, err = git.Projects.CreateProjectApprovalRule(project.ID, &gitlab.CreateProjectLevelRuleOptions{
-		Name:              gitlab.Ptr("Tutor Approval"),
-		ApprovalsRequired: gitlab.Ptr(int64(1)),
-		UserIDs:           gitlab.Ptr([]int64{tutorID}),
-	})
+	// 6. Approval rule (idempotent: skip if "Tutor Approval" rule exists)
+	err = ensureApprovalRule(git, project.ID, repoName, tutorID)
 	if err != nil {
-		log.Error("failed to add MR approval rule: ", err)
-		return errors.New("failed add MR approval rule")
+		return err
 	}
 
 	return nil
 }
 
-func addProjectMembers(git *gitlab.Client, projectID, tutorID, devID, devGroupID int64) error {
+func addProjectMembers(git *gitlab.Client, projectID int64, repoName string, tutorID, devID, devGroupID int64) error {
 	// Add student to the project
 	_, _, err := git.ProjectMembers.AddProjectMember(projectID, &gitlab.AddProjectMemberOptions{
 		UserID:      gitlab.Ptr(devID),
 		AccessLevel: gitlab.Ptr(gitlab.DeveloperPermissions),
 	})
-	if err != nil {
-		log.Error("failed to add student to project: ", err)
-		return errors.New("failed add student to project")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("add student %d to project %q: %w", devID, repoName, err)
 	}
 
 	// Add student to the developer group
@@ -218,9 +285,8 @@ func addProjectMembers(git *gitlab.Client, projectID, tutorID, devID, devGroupID
 		UserID:      gitlab.Ptr(devID),
 		AccessLevel: gitlab.Ptr(gitlab.DeveloperPermissions),
 	})
-	if err != nil {
-		log.Error("failed to add student to developer group: ", err)
-		return errors.New("failed add student to developer group")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("add student %d to developer group for %q: %w", devID, repoName, err)
 	}
 
 	// Add tutor to the project
@@ -228,53 +294,80 @@ func addProjectMembers(git *gitlab.Client, projectID, tutorID, devID, devGroupID
 		UserID:      gitlab.Ptr(tutorID),
 		AccessLevel: gitlab.Ptr(gitlab.DeveloperPermissions),
 	})
-	if err != nil {
-		log.Error("failed to add tutor to project: ", err)
-		return errors.New("failed add tutor to project")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("add tutor %d to project %q: %w", tutorID, repoName, err)
 	}
 
 	return nil
 }
 
-func createIssueBoard(git *gitlab.Client, projectID int64) error {
-	// Setup issue board
-	issueBoard, _, err := git.Boards.CreateIssueBoard(projectID, &gitlab.CreateIssueBoardOptions{
-		Name: gitlab.Ptr("Issue Board"),
-	})
+func ensureIssueBoard(git *gitlab.Client, projectID int64, repoName string) error {
+	boards, _, err := git.Boards.ListIssueBoards(projectID, nil)
 	if err != nil {
-		log.Error("failed to create issue board: ", err)
-		return errors.New("failed create issue board")
+		return fmt.Errorf("list issue boards for %q: %w", repoName, err)
 	}
 
-	// Add issue board lists
-	_, _, err = git.Boards.CreateIssueBoardList(projectID, issueBoard.ID, &gitlab.CreateIssueBoardListOptions{
-		LabelID: gitlab.Ptr(IN_PROGRESS_LABEL_ID),
-	})
-	if err != nil {
-		log.Error("failed to create issue board list: ", err)
-		return errors.New("failed create issue board list")
+	// Find existing board by name, or create one.
+	// GitLab allows duplicate board names, so we search first to avoid
+	// creating duplicates on partial-failure retries.
+	var board *gitlab.IssueBoard
+	for _, b := range boards {
+		if b.Name == "Issue Board" {
+			board = b
+			break
+		}
+	}
+	if board == nil {
+		board, _, err = git.Boards.CreateIssueBoard(projectID, &gitlab.CreateIssueBoardOptions{
+			Name: gitlab.Ptr("Issue Board"),
+		})
+		if err != nil {
+			return fmt.Errorf("create issue board for %q: %w", repoName, err)
+		}
 	}
 
-	_, _, err = git.Boards.CreateIssueBoardList(projectID, issueBoard.ID, &gitlab.CreateIssueBoardListOptions{
-		LabelID: gitlab.Ptr(IN_REVIEW_LABEL_ID),
-	})
-	if err != nil {
-		log.Error("failed to create issue board list: ", err)
-		return errors.New("failed create issue board list")
+	// Add lists individually (idempotent: skip if label list already exists on this board)
+	hasLabel := func(labelID int64) bool {
+		for _, l := range board.Lists {
+			if l.Label != nil && l.Label.ID == labelID {
+				return true
+			}
+		}
+		return false
 	}
+
+	if !hasLabel(IN_PROGRESS_LABEL_ID) {
+		_, _, err = git.Boards.CreateIssueBoardList(projectID, board.ID, &gitlab.CreateIssueBoardListOptions{
+			LabelID: gitlab.Ptr(IN_PROGRESS_LABEL_ID),
+		})
+		if err != nil && !isAlreadyExistsError(err) {
+			return fmt.Errorf("create 'In Progress' board list for %q: %w", repoName, err)
+		}
+	}
+
+	if !hasLabel(IN_REVIEW_LABEL_ID) {
+		_, _, err = git.Boards.CreateIssueBoardList(projectID, board.ID, &gitlab.CreateIssueBoardListOptions{
+			LabelID: gitlab.Ptr(IN_REVIEW_LABEL_ID),
+		})
+		if err != nil && !isAlreadyExistsError(err) {
+			return fmt.Errorf("create 'In Review' board list for %q: %w", repoName, err)
+		}
+	}
+
 	return nil
 }
 
-func createProjectFiles(git *gitlab.Client, projectID int64, studentName, submissionDeadline string) error {
+// createProjectFiles adds scaffold files to a student project.
+// Existing files are skipped (create-if-absent), not overwritten.
+func createProjectFiles(git *gitlab.Client, projectID int64, repoName, studentName, submissionDeadline string) error {
 	// Add custom README
 	_, _, err := git.RepositoryFiles.CreateFile(projectID, "README.md", &gitlab.CreateFileOptions{
 		Branch:        gitlab.Ptr("main"),
 		Content:       gitlab.Ptr(data.GetReadme(studentName, submissionDeadline)),
 		CommitMessage: gitlab.Ptr("Add custom README"),
 	})
-	if err != nil {
-		log.Error("failed to add custom README: ", err)
-		return errors.New("failed add custom README")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("create README for %q: %w", repoName, err)
 	}
 
 	// Add custom swiftlint
@@ -283,9 +376,8 @@ func createProjectFiles(git *gitlab.Client, projectID int64, studentName, submis
 		Content:       gitlab.Ptr(data.GetSwiftlint()),
 		CommitMessage: gitlab.Ptr("Add custom .swiftlint.yml"),
 	})
-	if err != nil {
-		log.Error("failed to add custom .swiftlint.yml: ", err)
-		return errors.New("failed add custom .swiftlint.yml")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("create .swiftlint.yml for %q: %w", repoName, err)
 	}
 
 	// Add custom gitignore
@@ -294,58 +386,35 @@ func createProjectFiles(git *gitlab.Client, projectID int64, studentName, submis
 		Content:       gitlab.Ptr(data.GetGitignore()),
 		CommitMessage: gitlab.Ptr("Add custom .gitignore"),
 	})
-	if err != nil {
-		log.Error("failed to add custom .gitignore: ", err)
-		return errors.New("failed add custom .gitignore")
+	if err != nil && !isAlreadyExistsError(err) {
+		return fmt.Errorf("create .gitignore for %q: %w", repoName, err)
 	}
 
 	return nil
 }
 
-func getSubGroup(groupName string, parentGroupID int64) (*gitlab.Group, error) {
-	git, err := getClient()
+// ensureApprovalRule creates the "Tutor Approval" rule if it doesn't exist.
+// GitLab does not enforce uniqueness on approval rule names, so we must
+// check first — create-then-handle-conflict is not possible for this resource.
+func ensureApprovalRule(git *gitlab.Client, projectID int64, repoName string, tutorID int64) error {
+	rules, _, err := git.Projects.GetProjectApprovalRules(projectID, nil)
 	if err != nil {
-		log.Error("failed to get group: ", err)
-		return nil, err
+		return fmt.Errorf("list approval rules for %q: %w", repoName, err)
 	}
-	groups, _, err := git.Groups.ListSubGroups(parentGroupID, &gitlab.ListSubGroupsOptions{
-		AllAvailable: gitlab.Ptr(true),
-	})
-	if err != nil {
-		log.Error("failed to get group: ", err)
-		return nil, err
-	}
-
-	for _, group := range groups {
-		log.Info("group: ", group.Name, " parent: ", group.ParentID)
-		if group.Name == groupName && group.ParentID == parentGroupID {
-			return group, nil
+	for _, r := range rules {
+		if r.Name == "Tutor Approval" {
+			return nil
 		}
 	}
-	return nil, errors.New("subgroup not found")
-}
 
-func checkIfSubGroupExists(groupName string, parentGroupID int64) (bool, *gitlab.Group, error) {
-	git, err := getClient()
-	if err != nil {
-		log.Error("failed to get group: ", err)
-		return false, nil, err
-	}
-
-	groups, _, err := git.Groups.ListSubGroups(parentGroupID, &gitlab.ListSubGroupsOptions{
-		Search:       gitlab.Ptr(groupName),
-		AllAvailable: gitlab.Ptr(true),
+	_, _, err = git.Projects.CreateProjectApprovalRule(projectID, &gitlab.CreateProjectLevelRuleOptions{
+		Name:              gitlab.Ptr("Tutor Approval"),
+		ApprovalsRequired: gitlab.Ptr(int64(1)),
+		UserIDs:           gitlab.Ptr([]int64{tutorID}),
 	})
 	if err != nil {
-		log.Error("failed to get group: ", err)
-		return false, nil, err
+		return fmt.Errorf("create approval rule for %q: %w", repoName, err)
 	}
 
-	for _, group := range groups {
-		log.Info("group: ", group.Name, " parent: ", group.ParentID)
-		if group.Name == groupName && group.ParentID == parentGroupID {
-			return true, group, nil
-		}
-	}
-	return false, nil, nil
+	return nil
 }

--- a/server/infrastructureSetup/gitlab.go
+++ b/server/infrastructureSetup/gitlab.go
@@ -128,7 +128,7 @@ func createDeveloperTopLevelGroup(parentGroupID int64) (*gitlab.Group, error) {
 	return createGitlabGroup(parentGroupID, "developer", gitlab.NoOneProjectCreation, gitlab.OwnerSubGroupCreationLevelValue)
 }
 
-// createTeachingGroup creates groups for tutors and coaches.
+// create Groups for tutors and coaches
 func createTeachingGroup(parentGroupID int64, groupName string) (*gitlab.Group, error) {
 	return createGitlabGroup(parentGroupID, groupName, gitlab.DeveloperProjectCreation, gitlab.OwnerSubGroupCreationLevelValue)
 }
@@ -147,6 +147,7 @@ func createGitlabGroup(parentGroupID int64, groupName string, projectCreationLev
 		return nil, err
 	}
 
+	// Create a group
 	group, _, err := git.Groups.CreateGroup(&gitlab.CreateGroupOptions{
 		Name:                  gitlab.Ptr(groupName),
 		ParentID:              gitlab.Ptr(parentGroupID),
@@ -155,6 +156,7 @@ func createGitlabGroup(parentGroupID int64, groupName string, projectCreationLev
 		AutoDevopsEnabled:     gitlab.Ptr(false),
 		Path:                  gitlab.Ptr(groupName),
 	})
+
 	if err != nil {
 		if !isAlreadyExistsError(err) {
 			return nil, fmt.Errorf("create group %q: %w", groupName, err)
@@ -176,9 +178,11 @@ func getUserID(username string) (*gitlab.User, error) {
 		return nil, fmt.Errorf("get client for user lookup %q: %w", username, err)
 	}
 
-	users, _, err := git.Users.ListUsers(&gitlab.ListUsersOptions{
+	userOpts := &gitlab.ListUsersOptions{
 		Username: gitlab.Ptr(username),
-	})
+	}
+
+	users, _, err := git.Users.ListUsers(userOpts)
 	if err != nil {
 		return nil, fmt.Errorf("list users for %q: %w", username, err)
 	}
@@ -203,20 +207,20 @@ func CreateStudentProject(repoName string, devID, tutorID, introCourseID int64, 
 		OnlyAllowMergeIfPipelineSucceeds: gitlab.Ptr(true),
 		BuildsAccessLevel:                gitlab.Ptr(gitlab.PrivateAccessControl),
 		ContainerRegistryAccessLevel:     gitlab.Ptr(gitlab.DisabledAccessControl),
-		EnvironmentsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl),
-		FeatureFlagsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl),
-		ForkingAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl),
-		InfrastructureAccessLevel:        gitlab.Ptr(gitlab.DisabledAccessControl),
-		PackagesEnabled:                  gitlab.Ptr(false),
-		ReleasesAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl),
-		SecurityAndComplianceAccessLevel: gitlab.Ptr(gitlab.DisabledAccessControl),
-		SnippetsAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl),
-		WikiAccessLevel:                  gitlab.Ptr(gitlab.DisabledAccessControl),
-		RequirementsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl),
-		ModelExperimentsAccessLevel:      gitlab.Ptr(gitlab.DisabledAccessControl),
-		ModelRegistryAccessLevel:         gitlab.Ptr(gitlab.DisabledAccessControl),
-		PagesAccessLevel:                 gitlab.Ptr(gitlab.DisabledAccessControl),
-		MonitorAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl),
+		EnvironmentsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl), // disable environments
+		FeatureFlagsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl), // disable feature flags
+		ForkingAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl), // disable forking
+		InfrastructureAccessLevel:        gitlab.Ptr(gitlab.DisabledAccessControl), // disable infrastructure
+		PackagesEnabled:                  gitlab.Ptr(false),                        // disable packages
+		ReleasesAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl), // disable releases
+		SecurityAndComplianceAccessLevel: gitlab.Ptr(gitlab.DisabledAccessControl), // disable security & compliance
+		SnippetsAccessLevel:              gitlab.Ptr(gitlab.DisabledAccessControl), // disable snippets
+		WikiAccessLevel:                  gitlab.Ptr(gitlab.DisabledAccessControl), // disable wiki
+		RequirementsAccessLevel:          gitlab.Ptr(gitlab.DisabledAccessControl), // disable requirements
+		ModelExperimentsAccessLevel:      gitlab.Ptr(gitlab.DisabledAccessControl), // disable model experiments
+		ModelRegistryAccessLevel:         gitlab.Ptr(gitlab.DisabledAccessControl), // disable model registry
+		PagesAccessLevel:                 gitlab.Ptr(gitlab.DisabledAccessControl), // disable pages
+		MonitorAccessLevel:               gitlab.Ptr(gitlab.DisabledAccessControl), // disable monitor
 	}
 
 	project, _, err := git.Projects.CreateProject(p)
@@ -256,6 +260,7 @@ func CreateStudentProject(repoName string, devID, tutorID, introCourseID int64, 
 	}
 
 	// 5. Members (idempotent: skip if already a member)
+	// Last step before approval rule as this might fail if the tutor is already a member of a "higher" group
 	err = addProjectMembers(git, project.ID, repoName, tutorID, devID, devGroupID)
 	if err != nil {
 		return err

--- a/server/infrastructureSetup/main.go
+++ b/server/infrastructureSetup/main.go
@@ -3,15 +3,31 @@ package infrastructureSetup
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
-	promptSDK "github.com/prompt-edu/prompt-sdk"
 	db "github.com/prompt-edu/prompt-intro-course/server/db/sqlc"
+	promptSDK "github.com/prompt-edu/prompt-sdk"
+	log "github.com/sirupsen/logrus"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
 func InitInfrastructureModule(routerGroup *gin.RouterGroup, queries db.Queries, conn *pgxpool.Pool, gitlabAccessToken string) {
 	setupInfrastructureRouter(routerGroup, promptSDK.AuthenticationMiddleware)
+
+	var gitlabClient *gitlab.Client
+	if gitlabAccessToken != "" {
+		client, err := gitlab.NewClient(gitlabAccessToken, gitlab.WithBaseURL("https://gitlab.lrz.de/api/v4"))
+		if err != nil {
+			log.Errorf("Failed to create GitLab client: %v — GitLab operations will fail", err)
+		} else {
+			log.Info("GitLab client initialized")
+			gitlabClient = client
+		}
+	} else {
+		log.Warn("GITLAB_ACCESS_TOKEN not set — GitLab operations will fail")
+	}
+
 	InfrastructureServiceSingleton = &InfrastructureService{
-		queries:           queries,
-		conn:              conn,
-		gitlabAccessToken: gitlabAccessToken,
+		queries:      queries,
+		conn:         conn,
+		gitlabClient: gitlabClient,
 	}
 }

--- a/server/infrastructureSetup/router.go
+++ b/server/infrastructureSetup/router.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	promptSDK "github.com/prompt-edu/prompt-sdk"
 	"github.com/prompt-edu/prompt-intro-course/server/infrastructureSetup/infrastructureDTO"
+	promptSDK "github.com/prompt-edu/prompt-sdk"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/server/infrastructureSetup/service.go
+++ b/server/infrastructureSetup/service.go
@@ -40,18 +40,22 @@ func CreateCourseInfrastructure(coursePhaseID uuid.UUID, semesterTag string) err
 	// Steps 2-5 are independent — collect all errors instead of failing fast
 	var errs []error
 
+	// 2.) Create the developer group
 	if _, err = createDeveloperTopLevelGroup(courseGroup.ID); err != nil {
 		errs = append(errs, fmt.Errorf("create developer group: %w", err))
 	}
 
+	// 3.) Create the tutor groups
 	if _, err = createTeachingGroup(courseGroup.ID, "tutors"); err != nil {
 		errs = append(errs, fmt.Errorf("create tutors group: %w", err))
 	}
 
+	// 4.) Create the coach group
 	if _, err = createTeachingGroup(courseGroup.ID, "coaches"); err != nil {
 		errs = append(errs, fmt.Errorf("create coaches group: %w", err))
 	}
 
+	// 5.) Create the introCourse group
 	if _, err = createTeachingGroup(courseGroup.ID, "Introcourse"); err != nil {
 		errs = append(errs, fmt.Errorf("create Introcourse group: %w", err))
 	}
@@ -126,6 +130,7 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 	err = CreateStudentProject(repoName, studentGitlabUser.ID, tutorGitlabUser.ID, introCourseGroup.ID, introCourseGroup.FullPath, developerGroup.ID, studentName, submissionDeadline)
 	if err != nil {
 		log.WithField("student", repoName).Error("Failed to create student project: ", err)
+		// store error in the db
 		dbError := InfrastructureServiceSingleton.queries.AddGitlabError(ctx, db.AddGitlabErrorParams{
 			CourseParticipationID: courseParticipationID,
 			CoursePhaseID:         coursePhaseID,
@@ -156,18 +161,21 @@ func getiPraktikumGroup() (*gitlab.Group, error) {
 	}
 
 	return ipraktikumGroup, nil
+
 }
 
 func GetAllStudentGitlabStatus(c context.Context, coursePhaseID uuid.UUID) ([]infrastructureDTO.GitlabStatus, error) {
 	ctxWithTimeout, cancel := db.GetTimeoutContext(c)
 	defer cancel()
 
+	// 1.) Get all gitlab status
 	gitlabStatuses, err := InfrastructureServiceSingleton.queries.GetAllGitlabStatus(ctxWithTimeout, coursePhaseID)
 	if err != nil {
 		return nil, fmt.Errorf("get gitlab statuses: %w", err)
 	}
 
 	return infrastructureDTO.GetGitlabStatusDTOsFromModels(gitlabStatuses), nil
+
 }
 
 func ManuallyOverwriteStudentGitlabStatus(c context.Context, coursePhaseID, courseParticipationID uuid.UUID) error {

--- a/server/infrastructureSetup/service.go
+++ b/server/infrastructureSetup/service.go
@@ -3,6 +3,7 @@ package infrastructureSetup
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -14,9 +15,9 @@ import (
 )
 
 type InfrastructureService struct {
-	queries           db.Queries
-	conn              *pgxpool.Pool
-	gitlabAccessToken string
+	queries      db.Queries
+	conn         *pgxpool.Pool
+	gitlabClient *gitlab.Client
 }
 
 var InfrastructureServiceSingleton *InfrastructureService
@@ -33,32 +34,30 @@ func CreateCourseInfrastructure(coursePhaseID uuid.UUID, semesterTag string) err
 
 	courseGroup, err := createCourseIterationGroup(semesterTag, ipraktikumGroup.ID)
 	if err != nil {
-		log.Error("Failed to create course iteration group: ", err)
 		return err
 	}
 
-	// 2.) Create the developer group
-	_, err = createDeveloperTopLevelGroup(courseGroup.ID)
-	if err != nil {
-		log.Error("Failed to create developer group: ", err)
+	// Steps 2-5 are independent — collect all errors instead of failing fast
+	var errs []error
+
+	if _, err = createDeveloperTopLevelGroup(courseGroup.ID); err != nil {
+		errs = append(errs, fmt.Errorf("create developer group: %w", err))
 	}
 
-	// 3.) Create the tutor groups
-	_, err = createTeachingGroup(courseGroup.ID, "tutors")
-	if err != nil {
-		log.Error("Failed to create tutor group: ", err)
+	if _, err = createTeachingGroup(courseGroup.ID, "tutors"); err != nil {
+		errs = append(errs, fmt.Errorf("create tutors group: %w", err))
 	}
 
-	// 4.) Create the coach group
-	_, err = createTeachingGroup(courseGroup.ID, "coaches")
-	if err != nil {
-		log.Error("Failed to create coach group: ", err)
+	if _, err = createTeachingGroup(courseGroup.ID, "coaches"); err != nil {
+		errs = append(errs, fmt.Errorf("create coaches group: %w", err))
 	}
 
-	// 5.) Create the introCourse group
-	_, err = createTeachingGroup(courseGroup.ID, "Introcourse")
-	if err != nil {
-		log.Error("Failed to create introCourse group: ", err)
+	if _, err = createTeachingGroup(courseGroup.ID, "Introcourse"); err != nil {
+		errs = append(errs, fmt.Errorf("create Introcourse group: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	return nil
@@ -71,11 +70,10 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 		CoursePhaseID:         coursePhaseID,
 	})
 	if err != nil {
-		log.Error("Failed to get developer profile: ", err)
-		return errors.New("failed to get developer profile")
-	} else if devProfile.GitlabUsername == "" {
-		log.Error("cannot create student repo due to missing student gitlab username")
-		return errors.New("cannot create student repo due to missing student gitlab username")
+		return fmt.Errorf("get developer profile: %w", err)
+	}
+	if devProfile.GitlabUsername == "" {
+		return fmt.Errorf("cannot create student repo: missing GitLab username for participation %s", courseParticipationID)
 	}
 
 	// 2.) Get the assigned tutor
@@ -84,11 +82,10 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 		CoursePhaseID:   coursePhaseID,
 	})
 	if err != nil {
-		log.Error("Failed to get assigned tutor: ", err)
-		return errors.New("failed to get assigned tutor")
-	} else if !tutor.GitlabUsername.Valid || tutor.GitlabUsername.String == "" {
-		log.Error("cannot create student repo due to missing tutor gitlab username")
-		return errors.New("cannot create student repo due to missing tutor gitlab username")
+		return fmt.Errorf("get assigned tutor: %w", err)
+	}
+	if !tutor.GitlabUsername.Valid || tutor.GitlabUsername.String == "" {
+		return fmt.Errorf("cannot create student repo: missing tutor GitLab username for participation %s", courseParticipationID)
 	}
 
 	log.Info("Creating student repo for student: ", devProfile.GitlabUsername, " with tutor: ", tutor.AssignedTutor)
@@ -96,14 +93,12 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 	// 3.) Get Gitlab IDs
 	studentGitlabUser, err := getUserID(devProfile.GitlabUsername)
 	if err != nil {
-		log.Error("Failed to get student gitlab id: ", err)
-		return errors.New("failed to get student gitlab id")
+		return fmt.Errorf("get student GitLab ID for %q: %w", devProfile.GitlabUsername, err)
 	}
 
 	tutorGitlabUser, err := getUserID(tutor.GitlabUsername.String)
 	if err != nil {
-		log.Error("Failed to get tutor gitlab id: ", err)
-		return errors.New("failed to get tutor gitlab id")
+		return fmt.Errorf("get tutor GitLab ID for %q: %w", tutor.GitlabUsername.String, err)
 	}
 
 	// 4.) Get required GitLab groups
@@ -114,27 +109,23 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 
 	semesterGroup, err := getSubGroup(semesterTag, ipraktikumGroup.ID)
 	if err != nil {
-		log.Error("Failed to get course group: ", err)
-		return err
+		return fmt.Errorf("get semester group %q: %w", semesterTag, err)
 	}
 
 	introCourseGroup, err := getSubGroup("Introcourse", semesterGroup.ID)
 	if err != nil {
-		log.Error("Failed to get intro course group: ", err)
-		return err
+		return fmt.Errorf("get Introcourse group: %w", err)
 	}
 
 	developerGroup, err := getSubGroup("developer", semesterGroup.ID)
 	if err != nil {
-		log.Error("Failed to get intro course group: ", err)
-		return err
+		return fmt.Errorf("get developer group: %w", err)
 	}
 
-	// 5.) Create the student group
-	err = CreateStudentProject(repoName, studentGitlabUser.ID, tutorGitlabUser.ID, introCourseGroup.ID, developerGroup.ID, studentName, submissionDeadline)
+	// 5.) Create the student project (fully idempotent — safe to re-run)
+	err = CreateStudentProject(repoName, studentGitlabUser.ID, tutorGitlabUser.ID, introCourseGroup.ID, introCourseGroup.FullPath, developerGroup.ID, studentName, submissionDeadline)
 	if err != nil {
-		log.Error("Failed to create student project: ", err)
-		// store error in the db
+		log.WithField("student", repoName).Error("Failed to create student project: ", err)
 		dbError := InfrastructureServiceSingleton.queries.AddGitlabError(ctx, db.AddGitlabErrorParams{
 			CourseParticipationID: courseParticipationID,
 			CoursePhaseID:         coursePhaseID,
@@ -152,8 +143,7 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 	})
 
 	if err != nil {
-		log.Error("Failed to update gitlab status in db: ", err)
-		return errors.New("failed to update gitlab status in db")
+		return fmt.Errorf("update gitlab status in db: %w", err)
 	}
 
 	return nil
@@ -162,34 +152,34 @@ func CreateStudentInfrastructure(ctx context.Context, coursePhaseID, courseParti
 func getiPraktikumGroup() (*gitlab.Group, error) {
 	ipraktikumGroup, err := getSubGroup(I_PRAKTIKUM_GROUP_NAME, ASE_GROUP_ID)
 	if err != nil {
-		log.Error("Failed to get group: ", err)
-		return nil, err
+		return nil, fmt.Errorf("get iPraktikum group: %w", err)
 	}
 
 	return ipraktikumGroup, nil
-
 }
 
 func GetAllStudentGitlabStatus(c context.Context, coursePhaseID uuid.UUID) ([]infrastructureDTO.GitlabStatus, error) {
-	// 1.) Get all gitlab status
-	gitlabStatuses, err := InfrastructureServiceSingleton.queries.GetAllGitlabStatus(c, coursePhaseID)
+	ctxWithTimeout, cancel := db.GetTimeoutContext(c)
+	defer cancel()
+
+	gitlabStatuses, err := InfrastructureServiceSingleton.queries.GetAllGitlabStatus(ctxWithTimeout, coursePhaseID)
 	if err != nil {
-		log.Error("Failed to get gitlab statuses: ", err)
-		return nil, err
+		return nil, fmt.Errorf("get gitlab statuses: %w", err)
 	}
 
 	return infrastructureDTO.GetGitlabStatusDTOsFromModels(gitlabStatuses), nil
-
 }
 
 func ManuallyOverwriteStudentGitlabStatus(c context.Context, coursePhaseID, courseParticipationID uuid.UUID) error {
-	err := InfrastructureServiceSingleton.queries.AddGitlabStatus(c, db.AddGitlabStatusParams{
+	ctxWithTimeout, cancel := db.GetTimeoutContext(c)
+	defer cancel()
+
+	err := InfrastructureServiceSingleton.queries.AddGitlabStatus(ctxWithTimeout, db.AddGitlabStatusParams{
 		CourseParticipationID: courseParticipationID,
 		CoursePhaseID:         coursePhaseID,
 	})
 	if err != nil {
-		log.Error("Failed to update gitlab status in db: ", err)
-		return err
+		return fmt.Errorf("update gitlab status in db: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Resolves #77 — makes the `infrastructureSetup` module's GitLab operations idempotent and safe to retry, reuses the GitLab client, and preserves original errors through the call chain.

### Changes

**Client lifecycle**
- `*gitlab.Client` created once at init, stored on `InfrastructureService` struct (was: created per API call via `getClient()`)
- `log.Errorf` on init failure instead of `log.Fatalf` — server stays up for non-GitLab endpoints
- Sentinel error `errGitLabClientNotInitialized` for clear failure when client is nil

**Idempotent student setup** — every step in `CreateStudentProject` is safe to re-run:

| Step | Strategy |
|---|---|
| Create project | Attempt create → on 409, fetch existing by deterministic path |
| Create files | Skip if file already exists (create-if-absent) |
| Branch protection | Skip if already protected |
| Add members | Skip if already a member |
| Issue board | Find board by name, add only missing label lists |
| Approval rule | Check existence first (GitLab allows duplicate rule names) |

**Idempotent group creation** — `createCourseIterationGroup` and `createGitlabGroup` now handle TOCTOU races: on conflict, re-fetch the existing group.

**Error handling**
- All `errors.New("generic message")` replaced with `fmt.Errorf("context: %w", err)` to preserve original GitLab API errors
- `CreateCourseInfrastructure` collects independent group-creation errors via `errors.Join` (was: silently swallowed)

**Code consolidation**
- `getSubGroup` + `checkIfSubGroupExists` → single `findSubGroup` implementation with `Search` param and `PerPage: 100`
- `db.GetTimeoutContext` added to DB-only service functions for consistency with other modules

### Not in scope (pre-existing, tracked separately)
- `handleError` leaking internal errors to HTTP clients
- `SCREAMING_SNAKE_CASE` constants
- Unused `coursePhaseID` param in `CreateCourseInfrastructure`
- `CreateStudentProject` param count (8 params — struct refactor is a follow-up)
- Unit tests for `isAlreadyExistsError` (follow-up)

### Files changed
- `server/infrastructureSetup/gitlab.go` — idempotent ops, `isAlreadyExistsError` helper, `findSubGroup`, TOCTOU recovery
- `server/infrastructureSetup/service.go` — struct change, `errors.Join`, `db.GetTimeoutContext`, error wrapping
- `server/infrastructureSetup/main.go` — init client once, `log.Errorf` not `Fatalf`
- `server/infrastructureSetup/router.go` — import reorder (gofmt)

## Test plan
- [ ] `go vet ./...` passes
- [ ] `gofmt -l` clean on changed files
- [ ] `go build ./...` passes
- [ ] All existing tests pass (`go test ./...`)
- [ ] Manual: run student setup → succeeds
- [ ] Manual: run student setup again for same student → succeeds (logs "project already exists")
- [ ] Manual: start server without `GITLAB_ACCESS_TOKEN` → server starts, GitLab ops fail gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idempotency across infrastructure setup so retries safely handle existing groups, projects, branches, labels, boards, members and approval rules.
  * Enhanced conflict detection to treat "already exists" as success and re-fetch resources deterministically instead of failing.
  * More robust error reporting and context for setup operations, reducing false failures and improving retry resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->