### PR TITLE
Fix tutor import 500 and seat-assignments infinite re-render

### DIFF
--- a/client/src/introCourse/network/mutations/importTutors.ts
+++ b/client/src/introCourse/network/mutations/importTutors.ts
@@ -10,11 +10,6 @@ export const importTutors = async (
     await introCourseAxiosInstance.post(
       `intro-course/api/course_phase/${coursePhaseID}/tutor/course/${courseID}`,
       tutors,
-      {
-        headers: {
-          'Content-Type': 'application/json-path+json',
-        },
-      },
     )
   } catch (err) {
     console.error(err)

--- a/client/src/introCourse/pages/SeatAssignment/hooks/useGetFilteredSeats.tsx
+++ b/client/src/introCourse/pages/SeatAssignment/hooks/useGetFilteredSeats.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Tutor } from '../../../interfaces/Tutor'
 import { Seat } from '../../../interfaces/Seat'
 import { TutorAssignmentFilterOptions } from '../interfaces/TutorAssignmentFilterOptions'
@@ -9,26 +10,31 @@ export const useGetFilteredSeats = (
   filterOptions: TutorAssignmentFilterOptions,
   tutors: Tutor[],
 ): Seat[] => {
-  return seats.filter((seat) => {
-    // Search filter
-    const matchesSearch =
-      seat?.seatName?.toLowerCase()?.includes(searchTerm.toLowerCase()) ||
-      false ||
-      (seat?.assignedTutor !== null &&
-        getTutorName(seat.assignedTutor, tutors)
-          ?.toLowerCase()
-          ?.includes(searchTerm.toLowerCase())) ||
-      false
+  return useMemo(
+    () =>
+      seats.filter((seat) => {
+        // Search filter
+        const matchesSearch =
+          seat?.seatName?.toLowerCase()?.includes(searchTerm.toLowerCase()) ||
+          false ||
+          (seat?.assignedTutor !== null &&
+            getTutorName(seat.assignedTutor, tutors)
+              ?.toLowerCase()
+              ?.includes(searchTerm.toLowerCase())) ||
+          false
 
-    // Assignment filter
-    const matchesAssignmentFilter =
-      (seat.assignedTutor && filterOptions.showAssigned) ||
-      (!seat.assignedTutor && filterOptions.showUnassigned)
+        // Assignment filter
+        const matchesAssignmentFilter =
+          (seat.assignedTutor && filterOptions.showAssigned) ||
+          (!seat.assignedTutor && filterOptions.showUnassigned)
 
-    // Mac filter
-    const matchesMacFilter =
-      (seat.hasMac && filterOptions.showWithMac) || (!seat.hasMac && filterOptions.showWithoutMac)
+        // Mac filter
+        const matchesMacFilter =
+          (seat.hasMac && filterOptions.showWithMac) ||
+          (!seat.hasMac && filterOptions.showWithoutMac)
 
-    return matchesSearch && matchesAssignmentFilter && matchesMacFilter
-  })
+        return matchesSearch && matchesAssignmentFilter && matchesMacFilter
+      }),
+    [seats, searchTerm, filterOptions, tutors],
+  )
 }

--- a/server/coreRequests/addTutorToKeycloakGroup.go
+++ b/server/coreRequests/addTutorToKeycloakGroup.go
@@ -3,8 +3,8 @@ package coreRequests
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
-	"net/http"
+	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 	"github.com/prompt-edu/prompt-intro-course/server/coreRequests/coreRequestDTOs"
@@ -36,9 +36,13 @@ func SendAddStudentsToKeycloakGroup(authHeader string, courseID uuid.UUID, stude
 		}
 	}()
 
-	if resp.StatusCode != http.StatusOK {
-		log.Error("Received non-OK response:", resp.Status)
-		return errors.New("non-OK response received")
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			log.Error("Failed to read error response body: ", readErr)
+		}
+		log.Errorf("Received non-2xx response from core server: status=%s body=%s", resp.Status, string(respBody))
+		return fmt.Errorf("core server returned %s: %s", resp.Status, string(respBody))
 	}
 
 	return nil

--- a/server/db/query/tutor.sql
+++ b/server/db/query/tutor.sql
@@ -1,6 +1,12 @@
 -- name: CreateTutor :exec
 INSERT INTO tutor (course_phase_id, id, first_name, last_name, email, matriculation_number, university_login)
-VALUES ($1, $2, $3, $4, $5, $6, $7);
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (course_phase_id, id) DO UPDATE SET
+  first_name = EXCLUDED.first_name,
+  last_name = EXCLUDED.last_name,
+  email = EXCLUDED.email,
+  matriculation_number = EXCLUDED.matriculation_number,
+  university_login = EXCLUDED.university_login;
 
 -- name: GetAllTutors :many
 SELECT * 

--- a/server/db/sqlc/tutor.sql.go
+++ b/server/db/sqlc/tutor.sql.go
@@ -15,6 +15,12 @@ import (
 const createTutor = `-- name: CreateTutor :exec
 INSERT INTO tutor (course_phase_id, id, first_name, last_name, email, matriculation_number, university_login)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (course_phase_id, id) DO UPDATE SET
+  first_name = EXCLUDED.first_name,
+  last_name = EXCLUDED.last_name,
+  email = EXCLUDED.email,
+  matriculation_number = EXCLUDED.matriculation_number,
+  university_login = EXCLUDED.university_login
 `
 
 type CreateTutorParams struct {


### PR DESCRIPTION
## Summary
- **Tutor import 500**: Keycloak group API status check only accepted HTTP 200; widened to any 2xx. Also reads and logs the response body on error for debuggability.
- **Tutor import idempotency**: `CreateTutor` SQL now uses `ON CONFLICT ... DO UPDATE` so re-importing tutors updates instead of failing on duplicate key.
- **Client Content-Type**: Removed incorrect `application/json-path+json` header from tutor import call (axios auto-sets `application/json`).
- **Seat-assignments crash (React #185)**: `useGetFilteredSeats` returned a new array every render, causing an infinite re-render loop via a dependent `useEffect`. Wrapped in `useMemo`.

## Test plan
- [ ] Import tutors via UI — should return 201 instead of 500
- [ ] Re-import same tutors — should succeed (upsert) instead of failing on duplicate key
- [ ] Navigate to seat-assignments page — should load without "Route loading failed"
- [ ] Search/filter seats — filtering still works correctly with memoized results

🤖 Generated with [Claude Code](https://claude.com/claude-code)