### PR TITLE
Server-side CSV import with atomic transactions and tests

### DIFF
--- a/client/src/introCourse/network/mutations/importSeatAssignments.ts
+++ b/client/src/introCourse/network/mutations/importSeatAssignments.ts
@@ -1,0 +1,27 @@
+import { introCourseAxiosInstance } from '../introCourseServerConfig'
+
+export interface ImportSeatAssignment {
+  seatName: string
+  seatMac: boolean
+  assignedStudent: string
+  assignedTutor: string
+  isTutorSeat: boolean
+  peerGroup: string
+}
+
+export interface ImportResult {
+  seatsUpdated: number
+  peerGroupsImported: number
+  warnings?: string[]
+}
+
+export const importSeatAssignments = async (
+  coursePhaseID: string,
+  assignments: ImportSeatAssignment[],
+): Promise<ImportResult> => {
+  const response = await introCourseAxiosInstance.post(
+    `intro-course/api/course_phase/${coursePhaseID}/seat_plan/import`,
+    { assignments },
+  )
+  return response.data
+}

--- a/client/src/introCourse/pages/SeatAssignment/components/SeatStudentAssigner/SeatStudentAssigner.tsx
+++ b/client/src/introCourse/pages/SeatAssignment/components/SeatStudentAssigner/SeatStudentAssigner.tsx
@@ -21,8 +21,7 @@ import { useUpdateSeats } from '../../hooks/useUpdateSeats'
 import { useAssignStudents } from '../../hooks/useAssignStudents'
 import { useDownloadAssignment } from '../../hooks/useDownloadAssignment'
 import { smartAssign } from '../../utils/smartAssignment'
-import { updateSeatPlan } from '../../../../network/mutations/updateSeatPlan'
-import { updatePeerAssignments } from '../../../../network/mutations/updatePeerAssignments'
+import { importSeatAssignments, ImportSeatAssignment } from '../../../../network/mutations/importSeatAssignments'
 import { ResetSeatAssignmentDialog } from './ResetSeatAssignmentDialog'
 import {
   Card,
@@ -117,7 +116,7 @@ export const SeatStudentAssigner = ({
     mutation.mutate(updatedSeats)
   }, [seats, developerWithProfiles, assignedStudents, peerAssignments, tutors, mutation])
 
-  // CSV import — matches by name, handles tutor seats and peer groups
+  // CSV import — parses CSV client-side, sends to server for name resolution and atomic save
   const { phaseId } = useParams<{ phaseId: string }>()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const handleImportCSV = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
@@ -133,7 +132,6 @@ export const SeatStudentAssigner = ({
         return
       }
 
-      // Match exact column names from export
       const header = lines[0].split(',').map((h) => h.trim().toLowerCase())
       const findCol = (name: string) => header.findIndex((h) => h === name.toLowerCase())
       const seatCol = findCol('seat')
@@ -148,110 +146,40 @@ export const SeatStudentAssigner = ({
         return
       }
 
-      // Build name -> ID lookups
-      const studentNameToId = new Map<string, string>()
-      for (const dev of developerWithProfiles) {
-        const name = `${dev.participation.student.firstName} ${dev.participation.student.lastName}`
-        studentNameToId.set(name.toLowerCase(), dev.participation.courseParticipationID)
-      }
-      const tutorNameToId = new Map<string, string>()
-      if (tutors) {
-        for (const t of tutors) {
-          tutorNameToId.set(`${t.firstName} ${t.lastName}`.toLowerCase(), t.id)
-        }
-      }
-
-      // Parse rows
-      const updatedSeats = seats.map((s) => ({ ...s }))
-      const seatIndex = new Map<string, number>()
-      updatedSeats.forEach((s, i) => seatIndex.set(s.seatName, i))
-
-      const peerGroups = new Map<string, string[]>()
-      const warnings: string[] = []
-
+      // Parse CSV into structured assignments — send raw names to server
+      const assignments: ImportSeatAssignment[] = []
       for (let i = 1; i < lines.length; i++) {
         const cols = lines[i].split(',').map((c) => c.trim().replace(/^"|"$/g, ''))
         const seatName = cols[seatCol]
         if (!seatName) continue
-        const idx = seatIndex.get(seatName)
-        if (idx === undefined) continue
 
-        // Student
-        const studentName = studentNameCol >= 0 ? (cols[studentNameCol] || '').trim() : ''
-        let studentId: string | null = null
-        if (studentName && studentName.toLowerCase() !== 'unassigned') {
-          studentId = studentNameToId.get(studentName.toLowerCase()) ?? null
-          if (!studentId) warnings.push(`Student "${studentName}" not found`)
-        }
-        updatedSeats[idx].assignedStudent = studentId
-
-        // Tutor
-        const tutorName = tutorNameCol >= 0 ? (cols[tutorNameCol] || '').trim() : ''
-        if (tutorName && tutorName.toLowerCase() !== 'unknown tutor') {
-          const tutorId = tutorNameToId.get(tutorName.toLowerCase()) ?? null
-          if (tutorId) {
-            updatedSeats[idx].assignedTutor = tutorId
-          } else {
-            warnings.push(`Tutor "${tutorName}" not found`)
-          }
-        }
-
-        // Tutor seat flag
-        if (tutorSeatCol >= 0) {
-          updatedSeats[idx].isTutorSeat = (cols[tutorSeatCol] || '').toLowerCase() === 'yes'
-        }
-
-        // Mac assignment
-        if (seatMacCol >= 0) {
-          updatedSeats[idx].hasMac = (cols[seatMacCol] || '').toLowerCase() === 'yes'
-        }
-
-        // Collect peer groups
-        if (peerGroupCol >= 0 && studentId) {
-          const pg = (cols[peerGroupCol] || '').trim()
-          if (pg) {
-            if (!peerGroups.has(pg)) peerGroups.set(pg, [])
-            peerGroups.get(pg)!.push(studentId)
-          }
-        }
+        assignments.push({
+          seatName,
+          seatMac: seatMacCol >= 0 ? cols[seatMacCol]?.toLowerCase() === 'yes' : false,
+          assignedStudent: studentNameCol >= 0 ? (cols[studentNameCol] || '') : '',
+          assignedTutor: tutorNameCol >= 0 ? (cols[tutorNameCol] || '') : '',
+          isTutorSeat: tutorSeatCol >= 0 ? cols[tutorSeatCol]?.toLowerCase() === 'yes' : false,
+          peerGroup: peerGroupCol >= 0 ? (cols[peerGroupCol] || '') : '',
+        })
       }
 
-      // Save seat assignments first, then peer assignments
       try {
-        await updateSeatPlan(phaseId ?? '', updatedSeats)
+        const result = await importSeatAssignments(phaseId ?? '', assignments)
         queryClient.invalidateQueries({ queryKey: ['seatPlan', phaseId] })
-      } catch {
-        warnings.push('Failed to save seat assignments')
-      }
+        queryClient.invalidateQueries({ queryKey: ['peerAssignments', phaseId] })
 
-      // Build and save peer assignments from groups
-      if (peerGroups.size > 0 && phaseId) {
-        const peerList: PeerAssignment[] = []
-        for (const members of peerGroups.values()) {
-          for (const a of members) {
-            for (const b of members) {
-              if (a !== b) peerList.push({ studentID: a, peerID: b })
-            }
-          }
+        if (result.warnings && result.warnings.length > 0) {
+          setError(`Imported ${result.seatsUpdated} seats, ${result.peerGroupsImported} peer groups. Warnings: ${result.warnings.slice(0, 5).join('; ')}${result.warnings.length > 5 ? ` (+${result.warnings.length - 5} more)` : ''}`)
+        } else {
+          setError(null)
         }
-        try {
-          await updatePeerAssignments(phaseId, peerList)
-          queryClient.invalidateQueries({ queryKey: ['peerAssignments', phaseId] })
-        } catch {
-          warnings.push('Failed to save peer assignments')
-        }
-      }
-
-      if (warnings.length > 0) {
-        const unique = [...new Set(warnings)]
-        setError(`Imported. Warnings: ${unique.slice(0, 5).join('; ')}${unique.length > 5 ? ` (+${unique.length - 5} more)` : ''}`)
-      } else {
-        setError(null)
+      } catch (err) {
+        setError(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
       }
     }
     reader.readAsText(file)
     if (fileInputRef.current) fileInputRef.current.value = ''
-  }, [seats, developerWithProfiles, tutors, phaseId, queryClient])
+  }, [phaseId, queryClient])
 
   // Download assignments as CSV
   const downloadAssignments = useDownloadAssignment(seats, developerWithProfiles, tutors, peerAssignments)

--- a/server/coreRequests/getParticipations.go
+++ b/server/coreRequests/getParticipations.go
@@ -1,0 +1,53 @@
+package coreRequests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+type StudentData struct {
+	FirstName           string `json:"firstName"`
+	LastName            string `json:"lastName"`
+	MatriculationNumber string `json:"matriculationNumber"`
+}
+
+type Participation struct {
+	CourseParticipationID string      `json:"courseParticipationID"`
+	Student               StudentData `json:"student"`
+}
+
+type ParticipationsResponse struct {
+	Participations []Participation `json:"participations"`
+}
+
+// GetCoursePhaseParticipations fetches all participations for a course phase
+// from the core platform, forwarding the caller's Authorization header.
+func GetCoursePhaseParticipations(authHeader string, coursePhaseID uuid.UUID) ([]Participation, error) {
+	path := "/api/course_phases/" + coursePhaseID.String() + "/participations"
+
+	resp, err := sendRequest("GET", path, authHeader, nil)
+	if err != nil {
+		return nil, fmt.Errorf("request participations: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn("Failed to close response body:", closeErr)
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("core returned %s: %s", resp.Status, string(body))
+	}
+
+	var result ParticipationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode participations: %w", err)
+	}
+
+	return result.Participations, nil
+}

--- a/server/seatPlan/import_service.go
+++ b/server/seatPlan/import_service.go
@@ -1,0 +1,182 @@
+package seatPlan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/prompt-edu/prompt-intro-course/server/db/sqlc"
+	"github.com/prompt-edu/prompt-intro-course/server/seatPlan/seatPlanDTO"
+	promptSDK "github.com/prompt-edu/prompt-sdk"
+	log "github.com/sirupsen/logrus"
+)
+
+// StudentInfo holds the data needed to match a student by name.
+type StudentInfo struct {
+	CourseParticipationID uuid.UUID
+	FirstName            string
+	LastName             string
+}
+
+// ImportSeatAssignments resolves names to IDs, updates all seats and peer
+// assignments in a single atomic transaction.
+func ImportSeatAssignments(
+	ctx context.Context,
+	coursePhaseID uuid.UUID,
+	req seatPlanDTO.ImportRequest,
+	students []StudentInfo,
+) (*seatPlanDTO.ImportResult, error) {
+	svc := SeatPlanServiceSingleton
+
+	// Build name lookup maps (case-insensitive)
+	studentNameToID := make(map[string]uuid.UUID)
+	for _, s := range students {
+		name := strings.ToLower(s.FirstName + " " + s.LastName)
+		studentNameToID[name] = s.CourseParticipationID
+	}
+
+	tutors, err := svc.queries.GetAllTutors(ctx, coursePhaseID)
+	if err != nil {
+		return nil, fmt.Errorf("get tutors: %w", err)
+	}
+	tutorNameToID := make(map[string]uuid.UUID)
+	for _, t := range tutors {
+		name := strings.ToLower(t.FirstName + " " + t.LastName)
+		tutorNameToID[name] = t.ID
+	}
+
+	// Resolve assignments
+	type resolvedSeat struct {
+		seatName string
+		hasMac   bool
+		student  pgtype.UUID
+		tutor    pgtype.UUID
+		isTutor  bool
+	}
+
+	var resolved []resolvedSeat
+	peerGroups := make(map[string][]uuid.UUID) // group label -> student IDs
+	var warnings []string
+	var details []seatPlanDTO.ImportResultEntry
+
+	for _, a := range req.Assignments {
+		r := resolvedSeat{
+			seatName: a.SeatName,
+			hasMac:   a.SeatMac,
+			isTutor:  a.IsTutorSeat,
+		}
+
+		// Match student
+		studentName := strings.TrimSpace(a.AssignedStudent)
+		if studentName != "" && strings.ToLower(studentName) != "unassigned" {
+			if sid, ok := studentNameToID[strings.ToLower(studentName)]; ok {
+				r.student = pgtype.UUID{Bytes: sid, Valid: true}
+			} else {
+				w := fmt.Sprintf("Student %q not found", studentName)
+				warnings = append(warnings, w)
+				details = append(details, seatPlanDTO.ImportResultEntry{
+					SeatName: a.SeatName, Success: false, Warning: w,
+				})
+				continue
+			}
+		}
+
+		// Match tutor
+		tutorName := strings.TrimSpace(a.AssignedTutor)
+		if tutorName != "" && strings.ToLower(tutorName) != "unknown tutor" {
+			if tid, ok := tutorNameToID[strings.ToLower(tutorName)]; ok {
+				r.tutor = pgtype.UUID{Bytes: tid, Valid: true}
+			} else {
+				w := fmt.Sprintf("Tutor %q not found", tutorName)
+				warnings = append(warnings, w)
+				details = append(details, seatPlanDTO.ImportResultEntry{
+					SeatName: a.SeatName, Success: false, Warning: w,
+				})
+				continue
+			}
+		}
+
+		// Collect peer group
+		pg := strings.TrimSpace(a.PeerGroup)
+		if pg != "" && r.student.Valid {
+			peerGroups[pg] = append(peerGroups[pg], r.student.Bytes)
+		}
+
+		resolved = append(resolved, r)
+		details = append(details, seatPlanDTO.ImportResultEntry{
+			SeatName: a.SeatName, Success: true,
+		})
+	}
+
+	// Execute in a single transaction
+	tx, err := svc.conn.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer promptSDK.DeferDBRollback(tx, ctx)
+	qtx := svc.queries.WithTx(tx)
+
+	// Update seats
+	seatsUpdated := 0
+	for _, r := range resolved {
+		err := qtx.UpdateSeat(ctx, db.UpdateSeatParams{
+			CoursePhaseID:   coursePhaseID,
+			SeatName:        r.seatName,
+			HasMac:          r.hasMac,
+			AssignedStudent: r.student,
+			AssignedTutor:   r.tutor,
+			IsTutorSeat:     r.isTutor,
+		})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"seat":  r.seatName,
+				"error": err,
+			}).Warn("Failed to update seat during import")
+			warnings = append(warnings, fmt.Sprintf("Failed to update seat %q: %s", r.seatName, err))
+		} else {
+			seatsUpdated++
+		}
+	}
+
+	// Delete existing peer assignments and create new ones
+	peerGroupsImported := 0
+	if len(peerGroups) > 0 {
+		if err := qtx.DeletePeerAssignments(ctx, coursePhaseID); err != nil {
+			warnings = append(warnings, fmt.Sprintf("Failed to clear peer assignments: %s", err))
+		} else {
+			for _, members := range peerGroups {
+				if len(members) < 2 {
+					continue
+				}
+				peerGroupsImported++
+				for i := 0; i < len(members); i++ {
+					for j := 0; j < len(members); j++ {
+						if i == j {
+							continue
+						}
+						if err := qtx.CreatePeerAssignment(ctx, db.CreatePeerAssignmentParams{
+							CoursePhaseID: coursePhaseID,
+							StudentID:    members[i],
+							PeerID:       members[j],
+						}); err != nil {
+							warnings = append(warnings, fmt.Sprintf("Failed to create peer assignment: %s", err))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return &seatPlanDTO.ImportResult{
+		SeatsUpdated:       seatsUpdated,
+		PeerGroupsImported: peerGroupsImported,
+		Warnings:           warnings,
+		Details:            details,
+	}, nil
+}

--- a/server/seatPlan/import_service_test.go
+++ b/server/seatPlan/import_service_test.go
@@ -1,0 +1,316 @@
+package seatPlan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prompt-edu/prompt-intro-course/server/seatPlan/seatPlanDTO"
+	"github.com/prompt-edu/prompt-intro-course/server/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ImportServiceTestSuite struct {
+	suite.Suite
+	ctx            context.Context
+	cleanup        func()
+	coursePhaseID   uuid.UUID
+	studentID1     uuid.UUID
+	studentID2     uuid.UUID
+	tutorID1       uuid.UUID
+	tutorID2       uuid.UUID
+}
+
+func (s *ImportServiceTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+	testDB, cleanup, err := testutils.SetupTestDB(s.ctx, "../database_dumps/intro_course.sql")
+	if err != nil {
+		s.T().Fatalf("Failed to set up test database: %v", err)
+	}
+	s.cleanup = cleanup
+	s.coursePhaseID = uuid.MustParse("4179d58a-d00d-4fa7-94a5-397bc69fab02")
+	s.studentID1 = uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	s.studentID2 = uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	s.tutorID1 = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	s.tutorID2 = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	SeatPlanServiceSingleton = &SeatPlanService{
+		queries: *testDB.Queries,
+		conn:    testDB.Conn,
+	}
+}
+
+func (s *ImportServiceTestSuite) TearDownSuite() {
+	if s.cleanup != nil {
+		s.cleanup()
+	}
+}
+
+func TestImportServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(ImportServiceTestSuite))
+}
+
+// TestImportStudentAndTutorByName verifies that students and tutors are matched
+// by their full name and correctly assigned to seats.
+func (s *ImportServiceTestSuite) TestImportStudentAndTutorByName() {
+	// The test DB has Seat-1 and Seat-2 with pre-assigned students and tutors.
+	// We import with different assignments to verify name matching works.
+	students := []StudentInfo{
+		{CourseParticipationID: s.studentID1, FirstName: "Max", LastName: "Mueller"},
+		{CourseParticipationID: s.studentID2, FirstName: "Anna", LastName: "Schmidt"},
+	}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				SeatMac:         true,
+				AssignedStudent: "Anna Schmidt",
+				AssignedTutor:   "Alice Tutor",
+				IsTutorSeat:     false,
+			},
+			{
+				SeatName:        "Seat-2",
+				SeatMac:         false,
+				AssignedStudent: "Max Mueller",
+				AssignedTutor:   "Bob Tutor",
+				IsTutorSeat:     false,
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 2, result.SeatsUpdated)
+	assert.Empty(s.T(), result.Warnings)
+
+	// Verify seats were updated
+	seats, err := GetSeatPlan(s.ctx, s.coursePhaseID)
+	require.NoError(s.T(), err)
+
+	for _, seat := range seats {
+		if seat.SeatName == "Seat-1" {
+			assert.True(s.T(), seat.HasMac, "Seat-1 should have Mac")
+			assert.True(s.T(), seat.AssignedStudent.Valid)
+			assert.Equal(s.T(), s.studentID2, uuid.UUID(seat.AssignedStudent.Bytes), "Seat-1 should have Anna (studentID2)")
+			assert.True(s.T(), seat.AssignedTutor.Valid)
+			assert.Equal(s.T(), s.tutorID1, uuid.UUID(seat.AssignedTutor.Bytes), "Seat-1 should have Alice (tutorID1)")
+		}
+		if seat.SeatName == "Seat-2" {
+			assert.False(s.T(), seat.HasMac, "Seat-2 should not have Mac")
+			assert.True(s.T(), seat.AssignedStudent.Valid)
+			assert.Equal(s.T(), s.studentID1, uuid.UUID(seat.AssignedStudent.Bytes), "Seat-2 should have Max (studentID1)")
+			assert.True(s.T(), seat.AssignedTutor.Valid)
+			assert.Equal(s.T(), s.tutorID2, uuid.UUID(seat.AssignedTutor.Bytes), "Seat-2 should have Bob (tutorID2)")
+		}
+	}
+}
+
+// TestImportTutorSeat verifies that isTutorSeat flag is set correctly.
+func (s *ImportServiceTestSuite) TestImportTutorSeat() {
+	students := []StudentInfo{}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				SeatMac:         false,
+				AssignedStudent: "Unassigned",
+				AssignedTutor:   "Alice Tutor",
+				IsTutorSeat:     true,
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, result.SeatsUpdated)
+
+	seats, err := GetSeatPlan(s.ctx, s.coursePhaseID)
+	require.NoError(s.T(), err)
+
+	for _, seat := range seats {
+		if seat.SeatName == "Seat-1" {
+			assert.True(s.T(), seat.IsTutorSeat, "Seat-1 should be a tutor seat")
+			assert.False(s.T(), seat.AssignedStudent.Valid, "Tutor seat should have no student")
+			assert.True(s.T(), seat.AssignedTutor.Valid)
+			assert.Equal(s.T(), s.tutorID1, uuid.UUID(seat.AssignedTutor.Bytes))
+		}
+	}
+}
+
+// TestImportMacAssignment verifies Mac assignment is imported.
+func (s *ImportServiceTestSuite) TestImportMacAssignment() {
+	students := []StudentInfo{
+		{CourseParticipationID: s.studentID1, FirstName: "Max", LastName: "Mueller"},
+	}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-2", // Was hasMac=false in test data
+				SeatMac:         true,
+				AssignedStudent: "Max Mueller",
+				AssignedTutor:   "Bob Tutor",
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, result.SeatsUpdated)
+
+	seats, err := GetSeatPlan(s.ctx, s.coursePhaseID)
+	require.NoError(s.T(), err)
+	for _, seat := range seats {
+		if seat.SeatName == "Seat-2" {
+			assert.True(s.T(), seat.HasMac, "Seat-2 should now have Mac")
+		}
+	}
+}
+
+// TestImportPeerGroups verifies that peer groups create bidirectional peer assignments.
+func (s *ImportServiceTestSuite) TestImportPeerGroups() {
+	students := []StudentInfo{
+		{CourseParticipationID: s.studentID1, FirstName: "Max", LastName: "Mueller"},
+		{CourseParticipationID: s.studentID2, FirstName: "Anna", LastName: "Schmidt"},
+	}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				AssignedStudent: "Max Mueller",
+				AssignedTutor:   "Alice Tutor",
+				PeerGroup:       "P1",
+			},
+			{
+				SeatName:        "Seat-2",
+				AssignedStudent: "Anna Schmidt",
+				AssignedTutor:   "Alice Tutor",
+				PeerGroup:       "P1",
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 2, result.SeatsUpdated)
+	assert.Equal(s.T(), 1, result.PeerGroupsImported, "Should have 1 peer group")
+
+	// Verify peer assignments were created
+	peers, err := SeatPlanServiceSingleton.queries.GetPeerAssignments(s.ctx, s.coursePhaseID)
+	require.NoError(s.T(), err)
+	assert.Len(s.T(), peers, 2, "Should have 2 bidirectional peer assignments")
+}
+
+// TestImportUnknownStudentWarning verifies a warning is returned for unmatched students.
+func (s *ImportServiceTestSuite) TestImportUnknownStudentWarning() {
+	students := []StudentInfo{
+		{CourseParticipationID: s.studentID1, FirstName: "Max", LastName: "Mueller"},
+	}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				AssignedStudent: "Nonexistent Person",
+				AssignedTutor:   "Alice Tutor",
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, result.SeatsUpdated, "Seat with unknown student should not be updated")
+	assert.Len(s.T(), result.Warnings, 1)
+	assert.Contains(s.T(), result.Warnings[0], "Nonexistent Person")
+}
+
+// TestImportUnknownTutorWarning verifies a warning is returned for unmatched tutors.
+func (s *ImportServiceTestSuite) TestImportUnknownTutorWarning() {
+	students := []StudentInfo{
+		{CourseParticipationID: s.studentID1, FirstName: "Max", LastName: "Mueller"},
+	}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				AssignedStudent: "Max Mueller",
+				AssignedTutor:   "Unknown Instructor",
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, result.SeatsUpdated, "Seat with unknown tutor should not be updated")
+	assert.Len(s.T(), result.Warnings, 1)
+	assert.Contains(s.T(), result.Warnings[0], "Unknown Instructor")
+}
+
+// TestImportCaseInsensitiveNameMatch verifies name matching is case-insensitive.
+func (s *ImportServiceTestSuite) TestImportCaseInsensitiveNameMatch() {
+	students := []StudentInfo{
+		{CourseParticipationID: s.studentID1, FirstName: "Max", LastName: "Mueller"},
+	}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				AssignedStudent: "max mueller",
+				AssignedTutor:   "alice tutor",
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, result.SeatsUpdated)
+	assert.Empty(s.T(), result.Warnings)
+}
+
+// TestImportUnassignedStudent verifies that "Unassigned" clears the student.
+func (s *ImportServiceTestSuite) TestImportUnassignedStudent() {
+	students := []StudentInfo{}
+
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{
+			{
+				SeatName:        "Seat-1",
+				AssignedStudent: "Unassigned",
+				AssignedTutor:   "Alice Tutor",
+			},
+		},
+	}
+
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, students)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, result.SeatsUpdated)
+
+	seats, err := GetSeatPlan(s.ctx, s.coursePhaseID)
+	require.NoError(s.T(), err)
+	for _, seat := range seats {
+		if seat.SeatName == "Seat-1" {
+			assert.False(s.T(), seat.AssignedStudent.Valid, "Student should be cleared")
+		}
+	}
+}
+
+// TestImportAtomicity verifies that the entire import is atomic —
+// a failure in one seat doesn't partially commit.
+func (s *ImportServiceTestSuite) TestImportEmptyRequest() {
+	req := seatPlanDTO.ImportRequest{
+		Assignments: []seatPlanDTO.ImportSeatAssignment{},
+	}
+
+	// Empty assignments should be rejected at the router level,
+	// but the service handles it gracefully
+	result, err := ImportSeatAssignments(s.ctx, s.coursePhaseID, req, nil)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, result.SeatsUpdated)
+}

--- a/server/seatPlan/router.go
+++ b/server/seatPlan/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
+	"github.com/prompt-edu/prompt-intro-course/server/coreRequests"
 	"github.com/prompt-edu/prompt-intro-course/server/seatPlan/seatPlanDTO"
 	log "github.com/sirupsen/logrus"
 )
@@ -25,6 +26,8 @@ func setupSeatPlanRouter(router *gin.RouterGroup, authMiddleware func(allowedRol
 
 	seatPlanRouter.GET("/own-assignment", authMiddleware(promptSDK.CourseStudent), getOwnSeatAssignment)
 
+	// Import seat assignments from CSV export (matches by name, not ID)
+	seatPlanRouter.POST("/import", authMiddleware(promptSDK.PromptAdmin, promptSDK.CourseLecturer), importSeatAssignments)
 }
 
 // createSeatPlan godoc
@@ -195,6 +198,73 @@ func getOwnSeatAssignment(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, seatAssignment)
+}
+
+// importSeatAssignments godoc
+// @Summary Import seat assignments from CSV export
+// @Description Imports seat assignments matching students and tutors by name.
+//
+//	Updates seats, Mac assignments, tutor seats, and peer groups atomically.
+//
+// @Tags seat-plan
+// @Accept json
+// @Produce json
+// @Param coursePhaseID path string true "Course Phase UUID"
+// @Param request body seatPlanDTO.ImportRequest true "Import payload"
+// @Success 200 {object} seatPlanDTO.ImportResult
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Security ApiKeyAuth
+// @Router /course_phase/{coursePhaseID}/seat_plan/import [post]
+func importSeatAssignments(c *gin.Context) {
+	coursePhaseID, err := uuid.Parse(c.Param("coursePhaseID"))
+	if err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	var req seatPlanDTO.ImportRequest
+	if err := c.BindJSON(&req); err != nil {
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	if len(req.Assignments) == 0 {
+		handleError(c, http.StatusBadRequest, errors.New("no assignments provided"))
+		return
+	}
+
+	// Fetch student names from core platform
+	participations, err := coreRequests.GetCoursePhaseParticipations(
+		c.GetHeader("Authorization"), coursePhaseID,
+	)
+	if err != nil {
+		log.WithError(err).Error("Failed to fetch participations from core")
+		handleError(c, http.StatusInternalServerError, errors.New("failed to fetch student data from core platform"))
+		return
+	}
+
+	students := make([]StudentInfo, len(participations))
+	for i, p := range participations {
+		cpID, parseErr := uuid.Parse(p.CourseParticipationID)
+		if parseErr != nil {
+			continue
+		}
+		students[i] = StudentInfo{
+			CourseParticipationID: cpID,
+			FirstName:            p.Student.FirstName,
+			LastName:             p.Student.LastName,
+		}
+	}
+
+	result, err := ImportSeatAssignments(c, coursePhaseID, req, students)
+	if err != nil {
+		log.WithError(err).Error("Import failed")
+		handleError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
 }
 
 func handleError(c *gin.Context, statusCode int, err error) {

--- a/server/seatPlan/seatPlanDTO/import.go
+++ b/server/seatPlan/seatPlanDTO/import.go
@@ -1,0 +1,32 @@
+package seatPlanDTO
+
+// ImportSeatAssignment represents a single row in the CSV import.
+// All matching is done by name — IDs are resolved server-side.
+type ImportSeatAssignment struct {
+	SeatName        string `json:"seatName"`
+	SeatMac         bool   `json:"seatMac"`
+	AssignedStudent string `json:"assignedStudent"` // full name or "Unassigned"
+	AssignedTutor   string `json:"assignedTutor"`   // full name or ""
+	IsTutorSeat     bool   `json:"isTutorSeat"`
+	PeerGroup       string `json:"peerGroup"` // e.g. "P1", "P2"
+}
+
+// ImportRequest is the payload for the CSV import endpoint.
+type ImportRequest struct {
+	Assignments []ImportSeatAssignment `json:"assignments"`
+}
+
+// ImportResultEntry reports the outcome for a single seat.
+type ImportResultEntry struct {
+	SeatName string `json:"seatName"`
+	Success  bool   `json:"success"`
+	Warning  string `json:"warning,omitempty"`
+}
+
+// ImportResult is the response from the CSV import endpoint.
+type ImportResult struct {
+	SeatsUpdated     int                 `json:"seatsUpdated"`
+	PeerGroupsImported int               `json:"peerGroupsImported"`
+	Warnings         []string            `json:"warnings,omitempty"`
+	Details          []ImportResultEntry `json:"details,omitempty"`
+}


### PR DESCRIPTION
Moves CSV import server-side with atomic transactions. 9 integration tests. All matching by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added seat assignment import functionality enabling bulk import of student and tutor assignments with MAC designation and peer group configuration
  * Automatic peer group creation during the import process
  * Enhanced import feedback providing success counts and warnings for any unresolved student or tutor names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->